### PR TITLE
docs(README.md): fix broken Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Distribute to many users for educational purposes, and if projects and Discord a
 
 ## Installation
 For a guid to how to install the application Refer to INSTALL.md
-=> https://github.com/mannmi/KoreanWonDetection/Documentation/INSTAL.md
+=> [Documentation/INSTAL.md](Documentation/INSTAL.md)
+
 
 ## Usage
 todo add usage description later
@@ -52,9 +53,9 @@ todo add usage description later
 
 Contributions are welcome! Please see the CONTRIBUTING.md, COMMIT_MESSAGE.md,CODE_OF_CONDUCT.md for guidelines.
 
-* CONTRIBUTING.md => https://github.com/mannmi/KoreanWonDetection/Documentation/CONTRIBUTING.md   
-* COMMIT_MESSAGE.md => https://github.com/mannmi/KoreanWonDetection/Documentation/COMMIT_MESSAGE.md
-* CODE_OF_CONDUCT.md => https://github.com/mannmi/KoreanWonDetection/Documentation/CODE_OF_CONDUCT.md
+* CONTRIBUTING.md => [Documentation/CONTRIBUTING.md](Documentation/CONTRIBUTING.md)  
+* COMMIT_MESSAGE.md => [Documentation/COMMIT_MESSAGE.md](Documentation/CONTRIBUTING.md)
+* CODE_OF_CONDUCT.md => [Documentation/CODE_OF_CONDUCT.md](Documentation/CODE_OF_CONDUCT.md)
 
 ## License
 


### PR DESCRIPTION
Fixes to README.md link to direct to the Documentation using Relative Path

closes #17