### PR TITLE
fix(TemplateMatcher.py): fixed function call providing 1 input.

### DIFF
--- a/src/image_template_matching/TemplateMatcher.py
+++ b/src/image_template_matching/TemplateMatcher.py
@@ -22,12 +22,10 @@ class TemplateMatcher:
 
     def process_frame(self, frame, orb):
         gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-        edges, bounding_boxes = self.edge_detection.detect_edges(gray)
+        edges = self.edge_detection.detect_edges(gray)
+
         highlighted_edges = cv2.cvtColor(edges, cv2.COLOR_GRAY2BGR)
         highlighted_edges[np.where((highlighted_edges == [255, 255, 255]).all(axis=2))] = [0, 0, 255]
-
-        for (x, y, w, h) in bounding_boxes:
-            cv2.rectangle(frame, (x, y), (x + w, y + h), (0, 255, 0), 2)
 
         kp_frame, des_frame = orb.detectAndCompute(gray, None)
         if des_frame is None:


### PR DESCRIPTION
This merge request addresses a ValueError in the process_frame method where the detect_edges function was expected to return two values, but only one value was returned. This issue arose because the code previously included a second bounding box, which has since been removed. The erroneous line was a remnant of that previous implementation.

### Changes:

Updated the process_frame method to correctly handle the single return value from detect_edges.

### Bug Fix:

Resolved the ValueError: too many values to unpack (expected 2) by adjusting the unpacking of the return value from detect_edges.
